### PR TITLE
Update dependency phantomjs to ~2.1.1

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.1",
   "devDependencies": {
     "mocha": "~1.17.0",
-    "phantomjs": "~1.9.2-6"
+    "phantomjs": "~2.1.1"
   }
 }


### PR DESCRIPTION
This Pull Request updates dependency [phantomjs](https://github.com/Medium/phantomjs) from `~1.9.2-6` to `~2.1.1`



<details>
<summary>Release Notes</summary>

### [`v2.1.1`](https://github.com/Medium/phantomjs/releases/v2.1.1)

Update installer to PhantomJS 2.1.1
Removes dependency on npmconf

---

### [`v2.1.2`](https://github.com/Medium/phantomjs/releases/v2.1.2)

Update installer to work with windows 2.1.1 package

---

### [`v2.1.3`](https://github.com/Medium/phantomjs/releases/v2.1.3)

- Changed package name to phantomjs-prebuilt
- Fix for cafiles with multiple certificates

---

### [`v2.1.7`](https://github.com/Medium/phantomjs/releases/v2.1.7)

- Change the default download location to github releases, per discussion on `https://github.com/Medium/phantomjs/issues/509` and `https://github.com/ariya/phantomjs/issues/13953`
- If there's a global npm phantomjs-prebuilt install on linux/osx, try to use that for local installs (windows is harder for complicated windows reasons)

---

</details>